### PR TITLE
Use old protect when reverting protection changes

### DIFF
--- a/flplusplus/src/patch.cpp
+++ b/flplusplus/src/patch.cpp
@@ -15,14 +15,14 @@ void detour(unsigned char* pOFunc, void* pHkFunc, unsigned char* originalData)
 	memcpy(&bPatch[1], &dwRelativeAddress, 4); // Copy the relative address to the byte array.
 	memcpy(originalData, pOFunc, 5);
 	memcpy(pOFunc, bPatch, 5); // Change the first 5 bytes to the JMP instruction.
-	VirtualProtect((void*)pOFunc, 5, dwOldProtection, NULL); // Set the protection back to what it was.
+	VirtualProtect((void*)pOFunc, 5, dwOldProtection, &dwOldProtection); // Set the protection back to what it was.
 }
 void undetour(unsigned char* pOFunc, unsigned char* originalData)
 {
 	DWORD dwOldProtection = 0; // Create a DWORD for VirtualProtect calls to allow us to write.
 	VirtualProtect((void*)pOFunc, 5, PAGE_EXECUTE_READWRITE, &dwOldProtection); // Allow us to write to the memory we need to change
 	memcpy(pOFunc, originalData, 5);
-	VirtualProtect((void*)pOFunc, 5, dwOldProtection, NULL); // Set the protection back to what it was.
+	VirtualProtect((void*)pOFunc, 5, dwOldProtection, &dwOldProtection); // Set the protection back to what it was.
 }
 
 void patch_bytes(unsigned int address, void* pData, unsigned int pSize)
@@ -30,7 +30,7 @@ void patch_bytes(unsigned int address, void* pData, unsigned int pSize)
     DWORD dwOldProtection = 0;
     VirtualProtect((void*)address, pSize, PAGE_READWRITE, &dwOldProtection);
     memcpy((void*)address, pData, pSize);
-    VirtualProtect((void*)address, pSize, dwOldProtection, NULL);
+    VirtualProtect((void*)address, pSize, dwOldProtection, &dwOldProtection);
 }
 
 }


### PR DESCRIPTION
Replaces NULL with a pointer to the old protection value in `patch.cpp`. It prevents crashes when launching Freelancer on some Windows installs. Credits go to @adoxa for discovering this.