### PR TITLE
Flexible LOD scale factors

### DIFF
--- a/flplusplus.ini
+++ b/flplusplus.ini
@@ -1,18 +1,8 @@
 ; Settings file for flplusplus
 [flplusplus]
 ; lod_scale
-; 0 = default lod 
-; 1 = 1.5x lod, draw distance
-; 2 = 2x
-; 3 = 3x
-; 4 = 4x
-; 5 = 5x
-; 6 = 6x
-; 7 = 7x
-; 8 = 8x
-; 10 = 10x
-; Note there is no 9x option
-lod_scale = 0
+; 1 = default lod
+lod_scale = 1
 ; save_folder_name
 ; Name of the save folder in Documents/My Games
 save_folder_name = Freelancer

--- a/flplusplus/def/Common.def
+++ b/flplusplus/def/Common.def
@@ -8,5 +8,6 @@ EXPORTS
 ?is_value@INI_Reader@@QAE_NPBD@Z
 ?get_value_bool@INI_Reader@@QAE_NI@Z
 ?get_value_int@INI_Reader@@QAEHI@Z
+?get_value_float@INI_Reader@@QAEMI@Z
 ?get_value_string@INI_Reader@@QAEPBDI@Z
 ?close@INI_Reader@@QAEXXZ

--- a/flplusplus/src/Common.cpp
+++ b/flplusplus/src/Common.cpp
@@ -16,7 +16,8 @@ typedef bool (__fastcall *pIniIs)(void*, int, LPCSTR); //is_header, is_value
 
 typedef bool (__fastcall *pIniGetValueBool)(void*, int, UINT); 
 typedef int (__fastcall *pIniGetValueInt)(void*, int, UINT);
-typedef LPCSTR (__fastcall *pIniGetValueString)(void*, int, UINT);  
+typedef float (__fastcall *pIniGetValueFloat)(void*, int, UINT);
+typedef LPCSTR (__fastcall *pIniGetValueString)(void*, int, UINT);
 //Functions
 
 static pIniVoid IniCreate;
@@ -29,6 +30,7 @@ static pIniRead IniReadValue;
 static pIniIs IniIsValue;
 static pIniGetValueBool IniGetValueBool;
 static pIniGetValueInt IniGetValueInt;
+static pIniGetValueFloat IniGetValueFloat;
 static pIniGetValueString IniGetValueString;
 static pIniVoid IniClose;
 
@@ -47,6 +49,7 @@ static void LoadFunctions()
     IniIsValue = (pIniIs)GetProcAddress(common, "?is_value@INI_Reader@@QAE_NPBD@Z");
     IniGetValueBool = (pIniGetValueBool)GetProcAddress(common, "?get_value_bool@INI_Reader@@QAE_NI@Z");
     IniGetValueInt = (pIniGetValueInt)GetProcAddress(common, "?get_value_int@INI_Reader@@QAEHI@Z");
+    IniGetValueFloat = (pIniGetValueFloat)GetProcAddress(common, "?get_value_float@INI_Reader@@QAEMI@Z");
     IniGetValueString = (pIniGetValueString)GetProcAddress(common, "?get_value_string@INI_Reader@@QAEPBDI@Z");
     IniClose = (pIniVoid)GetProcAddress(common, "?close@INI_Reader@@QAEXXZ");
     Loaded = 1;
@@ -100,6 +103,11 @@ bool INI_Reader::get_value_bool(UINT index)
 int INI_Reader::get_value_int(UINT index)
 {
     return IniGetValueInt(SELF, 0, index);
+}
+
+float INI_Reader::get_value_float(UINT index)
+{
+    return IniGetValueFloat(SELF, 0, index);
 }
 
 LPCSTR INI_Reader::get_value_string(UINT index)

--- a/flplusplus/src/Common.cpp
+++ b/flplusplus/src/Common.cpp
@@ -67,12 +67,12 @@ INI_Reader::INI_Reader()
     IniCreate(SELF, 0);
 }
 
-bool INI_Reader::open(LPCSTR filename, bool a)
+bool INI_Reader::open(LPCSTR path, bool throwExceptionOnFail)
 {
-    return IniOpen(SELF, 0, filename, a);
+    return IniOpen(SELF, 0, path, throwExceptionOnFail);
 }
 
-bool INI_Reader::read_header(void)
+bool INI_Reader::read_header()
 {
     return IniReadHeader(SELF, 0);    
 }
@@ -82,7 +82,7 @@ bool INI_Reader::is_header(LPCSTR header)
     return IniIsHeader(SELF, 0, header);
 }
 
-bool INI_Reader::read_value(void)
+bool INI_Reader::read_value()
 {
     return IniReadValue(SELF, 0);    
 }
@@ -107,7 +107,7 @@ LPCSTR INI_Reader::get_value_string(UINT index)
     return IniGetValueString(SELF, 0, index);
 }
 
-void INI_Reader::close(void)
+void INI_Reader::close()
 {
     IniClose(SELF, 0);
 }

--- a/flplusplus/src/Common.h
+++ b/flplusplus/src/Common.h
@@ -15,15 +15,15 @@ public:
     INI_Reader();
     ~INI_Reader();
 
-    bool open(LPCSTR, bool);
-    bool read_header(void);
-    bool is_header(LPCSTR);
-    bool read_value(void);
-    bool is_value(LPCSTR);
-    bool get_value_bool(UINT);
-    int get_value_int(UINT);
-    LPCSTR get_value_string(UINT);
-    void close(void);
+    bool open(LPCSTR path, bool throwExceptionOnFail);
+    bool read_header();
+    bool is_header(LPCSTR header);
+    bool read_value();
+    bool is_value(LPCSTR value);
+    bool get_value_bool(UINT index);
+    int get_value_int(UINT index);
+    LPCSTR get_value_string(UINT index);
+    void close();
 
 private:
     BYTE data[0x1568];

--- a/flplusplus/src/Common.h
+++ b/flplusplus/src/Common.h
@@ -22,6 +22,7 @@ public:
     bool is_value(LPCSTR value);
     bool get_value_bool(UINT index);
     int get_value_int(UINT index);
+    float get_value_float(UINT index);
     LPCSTR get_value_string(UINT index);
     void close();
 

--- a/flplusplus/src/config.cpp
+++ b/flplusplus/src/config.cpp
@@ -32,7 +32,7 @@ void config::init_from_file(const char *filename)
         while (reader.read_value())
         {
             if (reader.is_value("lod_scale"))
-                conf.lodscale = reader.get_value_int(0);
+                conf.lodscale = reader.get_value_float(0);
 
             if (reader.is_value("save_folder_name"))
                 conf.savefoldername = std::string(reader.get_value_string(0));

--- a/flplusplus/src/config.h
+++ b/flplusplus/src/config.h
@@ -10,7 +10,7 @@ namespace config {
     class ConfigData
     {
     public:
-        unsigned int lodscale;
+        float lodscale;
         std::string savefoldername;
         bool saveindirectory;
         bool removestartlocationwarning;

--- a/flplusplus/src/graphics.cpp
+++ b/flplusplus/src/graphics.cpp
@@ -5,18 +5,12 @@
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#include <unordered_map>
 
-struct x3 {
-    unsigned char v1, v2, v3;
-};
-
-int patch_lodranges(int scale)
+int patch_lodranges(const float* scale)
 {
-    if(scale < 0 || scale > 10 || scale == 9) return 0;
-    
-    
-    if(scale == 0) {
+    if(*scale < 1 || *scale > 1000000) return 0;
+
+    if(*scale == 1) {
         //1x lods
         unsigned char og1[5] = { 0x83, 0xFE, 0x08, 0x7D, 0x16 };
         patch::patch_bytes(OF_LODS_P1, (void*)og1, 5);
@@ -35,26 +29,12 @@ int patch_lodranges(int scale)
     unsigned char patch1[5] = { 0xE8, 0x7B, 0xFF, 0xFF, 0xFF };
     patch::patch_bytes(OF_LODS_P1, (void*)patch1, 5);
     patch::patch_uint16(OF_LODS_P2, 0x0DD8);
-    patch::patch_uint16(OF_LODS_P3, 0xC300);
+    patch::patch_uint8(OF_LODS_P3 + 1, 0xC3);
 
-    std::unordered_map<int, x3> lods = {
-        { 1, x3{ 0x20, 0xA2, 0x5C } }, //1.5x
-        { 2, x3{ 0xB4, 0x55, 0x5D } }, //2.0x
-        { 3, x3{ 0x28, 0x4F, 0x5D } }, //3.0x
-        { 4, x3{ 0x9C, 0xFC, 0x5C } }, //4.0x
-        { 5, x3{ 0x64, 0x84, 0x5D } }, //5.0x
-        { 6, x3{ 0x08, 0x4F, 0x5D } }, //6.0x
-        { 7, x3{ 0x50, 0x88, 0x5D } }, //7.0x
-        { 8, x3{ 0x54, 0x23, 0x44 } }, //8.0x
-        { 10, x3{ 0xFA, 0x1F, 0x57 } } //10.0x
-    };
+    // Write the pointer to the scale factor for the fmul st(0) instruction
+    patch::patch_uint32(OF_LODS_P4, (UINT) scale);
 
-    const auto it = lods.find(scale);
-
-    if (it != lods.end()) {
-        patch::patch_x3(OF_LODS_P4, it->second.v1, it->second.v2, it->second.v3);
-        ren_dist0 *= scale == 1 ? 1.5f : static_cast<float>(scale);
-    }
+    ren_dist0 *= *scale;
 
     patch::patch_float(OF_REN_DIST0, ren_dist0);
     patch::patch_float(OF_REN_DIST1, ren_dist1);
@@ -73,5 +53,5 @@ void graphics::init(bool version11)
     unsigned int address = (DWORD) common + (version11 ? F_OF_VIBROCENTRICFONT_V11 : F_OF_VIBROCENTRICFONT_V10);
     patch::patch_bytes(address, (void*)garbageFont, 2);
     //lod 0
-    patch_lodranges(config::get_config().lodscale);
+    patch_lodranges(&config::get_config().lodscale);
 }


### PR DESCRIPTION
Instead of having to rely on hard coded float constants in Freelancer.exe, the `lod_scale` option now supports arbitrary float values. For example, when entering values such as `42`, `6.5`, and `512.1337` the scale function will use that as the scale factor and it'll work just fine. I've currently set the limit to 1,000,000 as I had to draw the line somewhere.

I should mention that I haven't properly tested the new feature with GCC yet, so please check if that still works. I'm also not the best at documenting ini files, so I'll leave that up to you @CallumDev.

I've also cleaned up Common.h a little bit.